### PR TITLE
Disable daily rebuilds [ci skip]

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,6 @@
 name: Docker
 
 on:
-  schedule:
-    - cron: '26 13 * * *'
   push:
     branches: [ "trunk" ]
 


### PR DESCRIPTION
With the new dependabot rules, it will be automatically be rebuild on an base container update.